### PR TITLE
Add MNIST numbers classification example and run instructions

### DIFF
--- a/numbers_classification.py
+++ b/numbers_classification.py
@@ -1,0 +1,55 @@
+import lightning as L
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+
+class MNISTClassifier(L.LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(28 * 28, 128),
+            nn.ReLU(),
+            nn.Dropout(0.1),
+            nn.Linear(128, 10),
+        )
+        self.criterion = nn.CrossEntropyLoss()
+
+    def forward(self, x):
+        return self.model(x)
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=1e-3)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        loss = self.criterion(logits, y)
+        self.log("train_loss", loss)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        loss = self.criterion(logits, y)
+        acc = (logits.argmax(dim=-1) == y).float().mean()
+        self.log("val_loss", loss, prog_bar=True)
+        self.log("val_acc", acc, prog_bar=True)
+
+
+def create_dataloaders(batch_size: int = 64):
+    transform = transforms.ToTensor()
+    train_ds = datasets.MNIST(root="./data", train=True, download=True, transform=transform)
+    val_ds = datasets.MNIST(root="./data", train=False, download=True, transform=transform)
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
+    return train_loader, val_loader
+
+
+if __name__ == "__main__":
+    train_loader, val_loader = create_dataloaders()
+    model = MNISTClassifier()
+    trainer = L.Trainer(max_epochs=5)
+    trainer.fit(model, train_loader, val_loader)

--- a/readme-how-torun.md
+++ b/readme-how-torun.md
@@ -1,0 +1,21 @@
+# Numbers Classification Training
+
+This example trains a simple neural network to classify handwritten digits from the MNIST dataset using PyTorch Lightning.
+
+## Requirements
+
+- Python with `torch`, `torchvision`, and `lightning` installed. Install them with:
+
+```bash
+pip install torch torchvision lightning
+```
+
+## Run
+
+Execute the training script:
+
+```bash
+python numbers_classification.py
+```
+
+The script will download the MNIST dataset (if necessary) and train for five epochs, reporting validation loss and accuracy.


### PR DESCRIPTION
## Summary
- add simple PyTorch Lightning script for MNIST numbers classification
- document how to execute the example in a README

## Testing
- `python -m py_compile numbers_classification.py`
- `pre-commit run --files numbers_classification.py readme-how-torun.md` *(fails: command not found and installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689d97776dcc8326aafc8ebacdb32afe