### PR TITLE
Replace torchtext with datasets for transformer example

### DIFF
--- a/readme-for-transformer-training.md
+++ b/readme-for-transformer-training.md
@@ -2,13 +2,14 @@ Training Transformer with PyTorch Lightning
 ==========================================
 
 This repository includes `transformer_training.py`, a minimal example that trains a
-Transformer encoder on the AG_NEWS text classification dataset.
+Transformer encoder on the AG_NEWS text classification dataset using the
+HuggingFace Datasets library.
 
 ## Installation
 
 1. Install the required packages:
    ```bash
-   pip install torch torchtext pytorch-lightning
+   pip install torch datasets pytorch-lightning
    ```
 
 ## Training

--- a/requirements/pytorch/examples.txt
+++ b/requirements/pytorch/examples.txt
@@ -6,3 +6,4 @@ torchvision >=0.16.0, <0.21.0
 ipython[all] <8.15.0
 torchmetrics >=0.10.0, <1.5.0
 lightning-utilities >=0.8.0, <0.12.0
+datasets


### PR DESCRIPTION
## Summary
- remove torchtext dependency in `transformer_training.py`
- use HuggingFace `datasets` for loading AG_NEWS and custom vocabulary
- document new dependency and update example requirements

## Testing
- `python transformer_training.py --batch-size 64 --max-epochs 1` *(fails: ModuleNotFoundError: No module named 'datasets')*
- `pip install datasets` *(fails: ProxyError Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689da68176a08326a0e40f84309383c0