### PR TITLE
Add inference README with usage instructions

### DIFF
--- a/read-me-how-to-inference.md
+++ b/read-me-how-to-inference.md
@@ -1,0 +1,23 @@
+# Transformer Inference
+
+This document shows how to run the `transformer_inference.py` script to perform text classification with a trained Transformer model.
+
+## Requirements
+
+Install the required packages if they are not already present:
+
+```bash
+pip install torch datasets pytorch-lightning
+```
+
+A trained model checkpoint is expected at `lightning_logs/version_0/checkpoints/last.ckpt` unless another path is specified.
+
+## Run
+
+Provide one or more texts to classify:
+
+```bash
+python transformer_inference.py --checkpoint-path path/to/checkpoint.ckpt --texts "A sample news headline" "Another headline"
+```
+
+The script will print the model's logits and the predicted class for each provided text.


### PR DESCRIPTION
## Summary
- Document inference flow with a new `read-me-how-to-inference.md`
- Provide installation requirements and example command for `transformer_inference.py`

## Testing
- `pytest tests/tests_pytorch/utilities/test_imports.py::test_imports -q` *(fails: No module named 'lightning')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_689dbf85ec08832685b12d0dc5472c3c