### PR TITLE
Save transformer checkpoints to known path for inference

### DIFF
--- a/transformer_inference.py
+++ b/transformer_inference.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--checkpoint-path",
         type=str,
-        default="lightning_logs/version_0/checkpoints/last.ckpt",
+        default="transformer_model.ckpt",
         help="Path to a trained model checkpoint",
     )
     parser.add_argument("--texts", nargs="+", help="One or more texts to classify")

--- a/transformer_training.py
+++ b/transformer_training.py
@@ -120,6 +120,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train a Transformer text classifier with Lightning")
     parser.add_argument("--batch-size", type=int, default=64, help="Batch size for training")
     parser.add_argument("--max-epochs", type=int, default=5, help="Number of training epochs")
+    parser.add_argument(
+        "--save-path",
+        type=str,
+        default="transformer_model.ckpt",
+        help="File path to save the trained model checkpoint",
+    )
     args = parser.parse_args()
 
     dm = AGNewsDataModule(batch_size=args.batch_size)
@@ -128,3 +134,5 @@ if __name__ == "__main__":
     model = TransformerClassifier(vocab_size=dm.vocab_size, num_classes=dm.num_classes)
     trainer = L.Trainer(max_epochs=args.max_epochs)
     trainer.fit(model, dm)
+    trainer.save_checkpoint(args.save_path)
+    print(f"Model checkpoint saved to {args.save_path}")


### PR DESCRIPTION
## Summary
- allow specifying a save path for training checkpoints and write the path to disk
- default inference script to load the saved checkpoint

## Testing
- `python -m py_compile transformer_training.py transformer_inference.py`
- `python transformer_training.py --max-epochs 1 --batch-size 64 --save-path transformer_model.ckpt` *(fails: ModuleNotFoundError: No module named 'datasets')*
- `pip install datasets` *(fails: Could not find a version that satisfies the requirement datasets)*


------
https://chatgpt.com/codex/tasks/task_e_689de27f533083269c8a81676402ecfc