### PR TITLE
Document transformer checkpoint path for training and inference

### DIFF
--- a/read-me-how-to-inference.md
+++ b/read-me-how-to-inference.md
@@ -10,14 +10,14 @@ Install the required packages if they are not already present:
 pip install torch datasets pytorch-lightning
 ```
 
-A trained model checkpoint is expected at `lightning_logs/version_0/checkpoints/last.ckpt` unless another path is specified.
+Use the checkpoint saved during training (by default `transformer_model.ckpt`).
 
 ## Run
 
 Provide one or more texts to classify:
 
 ```bash
-python transformer_inference.py --checkpoint-path path/to/checkpoint.ckpt --texts "A sample news headline" "Another headline"
+python transformer_inference.py --checkpoint-path transformer_model.ckpt --texts "A sample news headline" "Another headline"
 ```
 
 The script will print the model's logits and the predicted class for each provided text.

--- a/readme-for-transformer-training.md
+++ b/readme-for-transformer-training.md
@@ -21,5 +21,11 @@ HuggingFace Datasets library.
    The script automatically downloads the AG_NEWS dataset and reports
    training and validation metrics.
 
+   The trained model checkpoint is saved to `transformer_model.ckpt` by default. Specify a custom path with `--save-path` if desired:
+   ```bash
+   python transformer_training.py --batch-size 64 --max-epochs 5 --save-path transformer_model.ckpt
+   ```
+   This checkpoint path can be used directly for inference.
+
 Adjust the command-line arguments to modify hyperparameters such as the
 batch size or number of epochs.


### PR DESCRIPTION
## Summary
- Clarify that transformer training saves checkpoints to `transformer_model.ckpt` by default
- Update inference instructions to load the same default checkpoint path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lightning', 'torchvision', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689de877cf10832698e3c5d85026c55b